### PR TITLE
fix(Navigation) breaking the mobile nav out of the position sticky context

### DIFF
--- a/public/scss/base/_globals.scss
+++ b/public/scss/base/_globals.scss
@@ -1,3 +1,7 @@
+*, *:before, *:after {
+  box-sizing: border-box;
+}
+
 body {
   @include fluid-font(16, 20);
   font-family: "Lato", sans-serif;

--- a/public/scss/components/_nav.scss
+++ b/public/scss/components/_nav.scss
@@ -101,8 +101,9 @@
     display: block;
     position: fixed;
     right: 0;
-    right: 0;
+    left: 0;
     top: 0;
+    height: 100dvh;
 
     @include breakpoint(md) {
       position: static;


### PR DESCRIPTION
## Addresses

- Issue with mobile nav not taking up full height after the nav was modified to be sticky.

## Testing

https://code.viget.com/nccs/